### PR TITLE
Fix the register function

### DIFF
--- a/src/Formol.jsx
+++ b/src/Formol.jsx
@@ -169,18 +169,27 @@ export default class Formol extends React.PureComponent {
   }
 
   register(name, element, validator, validityErrors) {
-    const { item, transientItem } = this.state.context
+    const { item } = this.state.context
     this.fields.names.push(name)
     this.fields.elements[name] = element
     this.fields.validators[name] = validator
     this.fields.validityErrors[name] = validityErrors
-    // If field is added as a later date we might need to copy its item value
-    // if it's not present in transientItem
-    if (item[name] !== void 0 && item[transientItem] === void 0) {
-      this.setStateContext({
-        transientItem: { ...transientItem, [name]: item[name] },
-      })
-    }
+
+    this.setState(prevState => {
+      const { context: prevContext } = prevState
+      const { transientItem: prevTransientItem } = prevContext
+
+      const newState = item.hasOwnProperty(name)
+        ? {
+            context: {
+              ...prevContext,
+              transientItem: { ...prevTransientItem, [name]: item[name] },
+            },
+          }
+        : { context: { ...prevContext } }
+
+      return newState
+    })
   }
 
   unregister(name) {

--- a/test/formol/conditional.test.jsx
+++ b/test/formol/conditional.test.jsx
@@ -242,4 +242,31 @@ describe('Conditional field', () => {
         .props().readOnly
     ).toBeTruthy()
   })
+  it('initializes multiple fields on show condition change', async () => {
+    const wrapper = mount(
+      <Formol
+        item={{
+          switchMe: false,
+          lName: 'Doe',
+          fName: 'John',
+        }}
+      >
+        <Field name="switchMe" type="switch">
+          Switch me
+        </Field>
+        <Conditional show={({ switchMe }) => switchMe}>
+          <Field name="lName">Last name</Field>
+          <Field name="fName">First name</Field>
+        </Conditional>
+      </Formol>
+    )
+    const switchBtn = () => wrapper.find('input[name="switchMe"]')
+
+    await switchBtn().simulate('change', { target: { checked: true } })
+    const lName = () => wrapper.find('input[name="lName"]')
+    const fName = () => wrapper.find('input[name="fName"]')
+
+    expect(lName().props().value).toBe('Doe')
+    expect(fName().props().value).toBe('John')
+  })
 })


### PR DESCRIPTION
## Context

When two or more Fields are used either inside the Conditional component or both
in their own Conditional with the same show condition, only the last
Field receive its initial value set in item attribute via Formol
component.

## The cause

When a Field is mounted, the register function is executed to
register the component in transientItem variable. But due to the async
nature of setState, the transientItem between Fields registration stays
the same.

I think this commit is an attempt to fix the bug https://github.com/Kozea/formol/commit/c12d07cdb293e9012b8062df11dacc25a1c5121e
But it seems to appear again https://github.com/Kozea/formol/issues/62