### PR TITLE
Reset this.state.modified on form submit

### DIFF
--- a/src/Formol.jsx
+++ b/src/Formol.jsx
@@ -266,6 +266,7 @@ export default class Formol extends React.PureComponent {
 
     if (!Object.keys(errors).length) {
       // No errors on submit
+      this.setState({ modified: false })
       if (item === emptyItem) {
         // Resetting form if no item was given
         this.handleCancel()

--- a/test/formol/index.test.jsx
+++ b/test/formol/index.test.jsx
@@ -2,6 +2,7 @@
 
 import { mount } from 'enzyme'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 
 import Formol, { Field } from '../../src'
 import InputField from '../../src/fields/InputField'
@@ -606,5 +607,29 @@ describe('Formol', () => {
       ['text'],
       false
     )
+  }, 30000)
+
+  it('internal value of modified must be false on successful submit', async () => {
+    const extra = jest.fn()
+    const wrapper = mount(
+      <Formol
+        onSubmit={jest.fn()}
+        item={{ username: '' }}
+        extra={({ modified }) => extra(modified)}
+      >
+        <Field type="text" name="username">
+          Username
+        </Field>
+      </Formol>
+    )
+
+    wrapper.find('input').simulate('change', { target: { value: 'Toto' } })
+    expect(wrapper.getDOMNode().checkValidity()).toBeTruthy()
+    await act(async () => {
+      await wrapper.find('.Formol_Formol__submit').simulate('submit')
+    })
+    const { length } = extra.mock.calls
+    // last value of `modified` must be false
+    expect(extra.mock.calls[length - 1][0]).toBeFalsy()
   }, 30000)
 })


### PR DESCRIPTION
Submiting did not make `this.state.modified` resetting to `false` again.

## Issue

For example, when passing `Prompt` component (`react-router-dom`) like so

```jsx
const MyForm = () => {
  const history = useHistory()
  
  const submitHandler = () => {
    const success = doSomethingWithFormItems()
    success && history.push('/somewhere/else')
  }

  return (
    <Formol onSubmit={submitHandler} extra={(state) => (<Prompt when={state.modified} />)}
      {/* ... */}
    </Formol>)
}
```

It will prompt the user a warning message to confirm the redirection after form submitting. This hangs
the redirection waiting for the user confirmation.

But the confirmation is implicit as soon as he clicks the submit button. Therefore there is no need to let the form in a modified state when submiting was successful.