### PR TITLE
Fix storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 
-const sass = require('dart-sass')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const rootDir = path.join(__dirname, '..')
 const dir = pth => (pth ? path.join(rootDir, pth) : rootDir)
@@ -57,7 +56,6 @@ module.exports = ({ config }) => {
         {
           loader: 'sass-loader',
           options: {
-            implementation: sass,
             sassOptions: {
               includePaths: [dir('src')],
             },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### [2.9.5](https://github.com/Kozea/formol/compare/v2.9.4...v2.9.5)
+
+- Remove special character `obj`
+
 ### [2.9.4](https://github.com/Kozea/formol/compare/v2.9.3...v2.9.4)
 
 - Make `Datefield` component accept other `react-datepicker` props


### PR DESCRIPTION
Broken since [v2.9.3](https://github.com/Kozea/formol/commit/e5c9b2c7ba10944d6f599c9ffad80ca24eeea32a) due to forgotten webpack config change after dart-sass replacement in https://github.com/Kozea/formol/pull/81

**Before this PR:**

![Selection_210](https://github.com/Kozea/formol/assets/5930831/c5f4c46f-52d0-4c1b-b825-a0c3b6c04206)


**After:**

![Selection_211](https://github.com/Kozea/formol/assets/5930831/85d3caa0-c003-4d59-a29d-4517c3f61610)


NB: also fix missing changelog update of v2.9.5