### PR TITLE
Use accent-color to style radio buttons and checkboxes

### DIFF
--- a/src/sass/default/fields/BooleanField.sass
+++ b/src/sass/default/fields/BooleanField.sass
@@ -34,6 +34,7 @@
     margin: 0 calc(#{$formol-field-margin} / 2) calc(#{$formol-field-margin} / 2) 0
 
 .Formol_BooleanField
+  accent-color: $formol-color-action
   margin: 0
 
 


### PR DESCRIPTION
according to `$formol-color-action` color

Available since 2021: https://caniuse.com/?search=accent-color

**Before:** 

![image](https://github.com/Kozea/formol/assets/5930831/3bfd5b30-8561-4312-8b99-198245698625)
![image](https://github.com/Kozea/formol/assets/5930831/d1cbb711-4b75-4fc6-91ac-1adbb70c5f74)


**After:**

![image](https://github.com/Kozea/formol/assets/5930831/932f502b-b7fd-4ab3-a816-c05adc3799ae)
![image](https://github.com/Kozea/formol/assets/5930831/707949a8-c9b9-4524-9b70-3bcb64a1c8c1)

