### PR TITLE
Add auto-slash to DateField 

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "react-icons": "^3.9.0",
     "react-quill": "^1.3.3",
     "react-select": "^3.1.0",
+    "react-text-mask": "^5.5.0",
     "react-window": "^1.8.5",
     "zxcvbn": "^4.4.2"
   },

--- a/src/__mocks__/react-text-mask.jsx
+++ b/src/__mocks__/react-text-mask.jsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+
+// https://github.com/text-mask/text-mask/issues/427#issuecomment-479945031
+const mock = React.forwardRef(
+  (props, ref) => {
+    const { render, ...otherProps } = props
+
+    return render ? (
+      render(ref, { ...otherProps })
+    ) : (
+      <input ref={ref} {...otherProps} />
+    )
+  }
+)
+
+export default mock

--- a/src/fields/DateField.jsx
+++ b/src/fields/DateField.jsx
@@ -3,6 +3,7 @@ import Datepicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import { format } from 'date-fns'
 import { fr, enUS } from 'date-fns/locale'
+import MaskedInput from 'react-text-mask'
 
 import { block } from '../utils'
 
@@ -13,7 +14,7 @@ export default class DateField extends React.PureComponent {
   componentDidMount() {
     const { readOnly, disabled, elementRef } = this.props
     if (!(readOnly || disabled)) {
-      elementRef.current = this.datepicker.input
+      elementRef.current = this.datepicker.customInput
     }
   }
   componentWillUnmount() {
@@ -60,6 +61,12 @@ export default class DateField extends React.PureComponent {
         placeholderText={placeholder || dateFormat}
         {...restOfProps}
         {...datepickerProps}
+        customInput={
+          <MaskedInput
+            type="text"
+            mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
+          />
+        }
       />
     )
   }

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -8830,6 +8830,20 @@ exports[`Storyshots Field Test All fields 1`] = `
           <input
             className="Formol_DateField Formol_InputField Formol_Field__element"
             disabled={false}
+            mask={
+              Array [
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+              ]
+            }
             name="date"
             onBlur={[Function]}
             onChange={[Function]}
@@ -15804,6 +15818,20 @@ Area"
           <input
             className="Formol_DateField Formol_InputField Formol_Field__element"
             disabled={false}
+            mask={
+              Array [
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+              ]
+            }
             name="date"
             onBlur={[Function]}
             onChange={[Function]}
@@ -24082,6 +24110,20 @@ exports[`Storyshots Field Test/Fields date field 1`] = `
           <input
             className="Formol_DateField Formol_InputField Formol_Field__element"
             disabled={false}
+            mask={
+              Array [
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+              ]
+            }
             name="date"
             onBlur={[Function]}
             onChange={[Function]}
@@ -33032,6 +33074,20 @@ exports[`Storyshots Field Test/Fields with initial value date field 1`] = `
           <input
             className="Formol_DateField Formol_InputField Formol_Field__element"
             disabled={false}
+            mask={
+              Array [
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                "/",
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+                /\\\\d/,
+              ]
+            }
             name="date"
             onBlur={[Function]}
             onChange={[Function]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9090,6 +9090,15 @@ prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.5.6:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-information@^5.0.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.4.0.tgz#16e08f13f4e5c4a7be2e4ec431c01c4f8dba869a"
@@ -9501,7 +9510,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9615,6 +9624,13 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.13.1:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-text-mask@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/react-text-mask/-/react-text-mask-5.5.0.tgz#468ea690160b364981205f5633e7475e939383ff"
+  integrity sha512-SLJlJQxa0uonMXsnXRpv5abIepGmHz77ylQcra0GNd7Jtk4Wj2Mtp85uGQHv1avba2uI8ZvRpIEQPpJKsqRGYw==
+  dependencies:
+    prop-types "^15.5.6"
 
 react-textarea-autosize@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
Add auto-slash to DateField using [MaskedInput](https://github.com/text-mask/text-mask/tree/master/react#readme).

**before**:


https://github.com/Kozea/formol/assets/5930831/b765b426-2020-4fa6-9b53-910c3dd22de7



**now**:


https://github.com/Kozea/formol/assets/5930831/f34b3802-8b2e-47b9-923c-3fb6d7d1c939

