### PR TITLE
Add optional basic prop to PasswordStrengthField

### DIFF
--- a/src/sass/default/fields/PasswordStrengthField.sass
+++ b/src/sass/default/fields/PasswordStrengthField.sass
@@ -1,5 +1,15 @@
 @use 'sass:math'
 
+@mixin strength-meter($steps, $strengths)
+  @for $i from 0 through $steps
+      .Formol_PasswordStrengthField--score-#{$i} .Formol_PasswordStrengthField
+        &__strength
+          background-color: nth($strengths, $i + 1)
+          width: percentage(.1 + $i * math.div(.9, $steps))
+
+        &__description
+          color: nth($strengths, $i + 1)
+
 .Formol_PasswordStrengthField
   &__description
     font-size: $formol-font-size * .85
@@ -11,18 +21,13 @@
     transition: background-color 250ms, width 250ms
 
 
-  $strengths: $formol-color-inactive, $formol-color-inactive, $formol-color, $formol-color, $formol-color-action, $formol-color-action
-  $steps: 5
+  &__default
+    $strengths: $formol-color-inactive, $formol-color-inactive, $formol-color, $formol-color, $formol-color-action, $formol-color-action
+    @include strength-meter(5, $strengths)
 
-  @for $i from 0 through $steps
-    &--score-#{$i} .Formol_PasswordStrengthField
-      &__strength
-        background-color: nth($strengths, $i + 1)
-        width: percentage(.1 + $i * math.div(.9, $steps))
-
-      &__description
-        color: nth($strengths, $i + 1)
-
+  &__basic
+    $basic-strengths: $formol-color-inactive, $formol-color, $formol-color-action
+    @include strength-meter(2, $basic-strengths)
 
 .Formol_Field--readOnly .Formol_PasswordStrengthField
   &__strength, &__description

--- a/stories/misc.stories.jsx
+++ b/stories/misc.stories.jsx
@@ -589,3 +589,17 @@ storiesOf('Miscellaneous', module)
       </Formol>
     ))
   )
+  .add(
+    'Basic password-strength field',
+    withStateForm(props => (
+      <Formol {...props} components={{ SubmitButton, CancelButton }}>
+        <h1>Basic password-strength field (3 levels)</h1>
+        <Field type="password-strength" basic>
+          Password
+        </Field>
+
+        <h2>Default password-strength field (6 levels)</h2>
+        <Field type="password-strength">Password</Field>
+      </Formol>
+    ))
+  )

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -42435,6 +42435,263 @@ exports[`Storyshots Miscellaneous Asynchronous choices 1`] = `
 </form>
 `;
 
+exports[`Storyshots Miscellaneous Basic password-strength field 1`] = `
+<form
+  className={
+    Block {
+      "block": "Formol",
+      "element": null,
+      "mixed": Array [],
+      "modifier": Object {
+        "errors": false,
+        "loading": false,
+      },
+      "s": "Formol_Formol",
+      "settings": Object {
+        "elementDelimiter": "__",
+        "modifierDelimiter": "--",
+        "modifierValueDelimiter": "-",
+        "namespace": "Formol_",
+      },
+      "subs": Array [],
+    }
+  }
+  onSubmit={[Function]}
+>
+  <h1>
+    Basic password-strength field (3 levels)
+  </h1>
+  <div
+    className={
+      Block {
+        "block": "Field",
+        "element": null,
+        "mixed": Array [],
+        "modifier": Object {
+          "disabled": undefined,
+          "error": false,
+          "focus": false,
+          "modified": false,
+          "name": "password",
+          "readOnly": undefined,
+          "required": false,
+          "type": "password-strength",
+        },
+        "s": "Formol_Field Formol_Field--type-password-strength Formol_Field--name-password",
+        "settings": Object {
+          "elementDelimiter": "__",
+          "modifierDelimiter": "--",
+          "modifierValueDelimiter": "-",
+          "namespace": "Formol_",
+        },
+        "subs": Array [],
+      }
+    }
+  >
+    <label
+      className={
+        Block {
+          "block": "Field",
+          "element": "label",
+          "mixed": Array [],
+          "modifier": Object {},
+          "s": "Formol_Field__label",
+          "settings": Object {
+            "elementDelimiter": "__",
+            "modifierDelimiter": "--",
+            "modifierValueDelimiter": "-",
+            "namespace": "Formol_",
+          },
+          "subs": Array [],
+        }
+      }
+      onClick={[Function]}
+    >
+      <span
+        className={
+          Block {
+            "block": "Field",
+            "element": "title",
+            "mixed": Array [],
+            "modifier": Object {},
+            "s": "Formol_Field__title",
+            "settings": Object {
+              "elementDelimiter": "__",
+              "modifierDelimiter": "--",
+              "modifierValueDelimiter": "-",
+              "namespace": "Formol_",
+            },
+            "subs": Array [],
+          }
+        }
+        id="labelContent"
+      >
+        Password
+      </span>
+      Loading
+    </label>
+  </div>
+  <h2>
+    Default password-strength field (6 levels)
+  </h2>
+  <div
+    className={
+      Block {
+        "block": "Field",
+        "element": null,
+        "mixed": Array [],
+        "modifier": Object {
+          "disabled": undefined,
+          "error": false,
+          "focus": false,
+          "modified": false,
+          "name": "password",
+          "readOnly": undefined,
+          "required": false,
+          "type": "password-strength",
+        },
+        "s": "Formol_Field Formol_Field--type-password-strength Formol_Field--name-password",
+        "settings": Object {
+          "elementDelimiter": "__",
+          "modifierDelimiter": "--",
+          "modifierValueDelimiter": "-",
+          "namespace": "Formol_",
+        },
+        "subs": Array [],
+      }
+    }
+  >
+    <label
+      className={
+        Block {
+          "block": "Field",
+          "element": "label",
+          "mixed": Array [],
+          "modifier": Object {},
+          "s": "Formol_Field__label",
+          "settings": Object {
+            "elementDelimiter": "__",
+            "modifierDelimiter": "--",
+            "modifierValueDelimiter": "-",
+            "namespace": "Formol_",
+          },
+          "subs": Array [],
+        }
+      }
+      onClick={[Function]}
+    >
+      <span
+        className={
+          Block {
+            "block": "Field",
+            "element": "title",
+            "mixed": Array [],
+            "modifier": Object {},
+            "s": "Formol_Field__title",
+            "settings": Object {
+              "elementDelimiter": "__",
+              "modifierDelimiter": "--",
+              "modifierValueDelimiter": "-",
+              "namespace": "Formol_",
+            },
+            "subs": Array [],
+          }
+        }
+        id="labelContent"
+      >
+        Password
+      </span>
+      Loading
+    </label>
+  </div>
+  <button
+    className={
+      Block {
+        "block": "Formol",
+        "element": "submit",
+        "mixed": Array [],
+        "modifier": Object {},
+        "s": "Formol_Formol__submit",
+        "settings": Object {
+          "elementDelimiter": "__",
+          "modifierDelimiter": "--",
+          "modifierValueDelimiter": "-",
+          "namespace": "Formol_",
+        },
+        "subs": Array [],
+      }
+    }
+    disabled={true}
+    title="No change in form"
+    type="submit"
+  >
+    <svg
+      fill="currentColor"
+      height="1em"
+      stroke="currentColor"
+      strokeWidth="0"
+      style={
+        Object {
+          "color": "green",
+        }
+      }
+      viewBox="0 0 512 512"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+      />
+    </svg>
+     
+    Submit
+  </button>
+  <button
+    className={
+      Block {
+        "block": "Formol",
+        "element": "cancel",
+        "mixed": Array [],
+        "modifier": Object {},
+        "s": "Formol_Formol__cancel",
+        "settings": Object {
+          "elementDelimiter": "__",
+          "modifierDelimiter": "--",
+          "modifierValueDelimiter": "-",
+          "namespace": "Formol_",
+        },
+        "subs": Array [],
+      }
+    }
+    disabled={true}
+    onClick={[Function]}
+    title="No change in form"
+    type="button"
+  >
+    <svg
+      fill="currentColor"
+      height="1em"
+      stroke="currentColor"
+      strokeWidth="0"
+      style={
+        Object {
+          "color": "red",
+        }
+      }
+      viewBox="0 0 512 512"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M212.333 224.333H12c-6.627 0-12-5.373-12-12V12C0 5.373 5.373 0 12 0h48c6.627 0 12 5.373 12 12v78.112C117.773 39.279 184.26 7.47 258.175 8.007c136.906.994 246.448 111.623 246.157 248.532C504.041 393.258 393.12 504 256.333 504c-64.089 0-122.496-24.313-166.51-64.215-5.099-4.622-5.334-12.554-.467-17.42l33.967-33.967c4.474-4.474 11.662-4.717 16.401-.525C170.76 415.336 211.58 432 256.333 432c97.268 0 176-78.716 176-176 0-97.267-78.716-176-176-176-58.496 0-110.28 28.476-142.274 72.333h98.274c6.627 0 12 5.373 12 12v48c0 6.627-5.373 12-12 12z"
+      />
+    </svg>
+     
+    Cancel
+  </button>
+</form>
+`;
+
 exports[`Storyshots Miscellaneous Custom button components 1`] = `
 <form
   className={

--- a/test/formol/types/password-strength.test.jsx
+++ b/test/formol/types/password-strength.test.jsx
@@ -194,4 +194,46 @@ describe('Password Strength field', () => {
 
     expect(wrapper.getDOMNode().checkValidity()).toBeFalsy()
   })
+
+  describe('basic', () => {
+    it('only uses 3 levels of strength', async () => {
+      const wrapper = mount(
+        <Formol item={{ password: '' }}>
+          <Field type="password-strength" basic>
+            Password
+          </Field>
+        </Formol>
+      )
+
+      const asyncWrapper = () => wrapper.find('AsyncWrapper')
+      expect(asyncWrapper().text()).toEqual('Loading')
+      await asyncWrapper().instance()._promise
+      wrapper.update()
+      expect(asyncWrapper().text()).not.toEqual('Loading')
+
+      const input = () =>
+        wrapper
+          .find('Field')
+          .find('input')
+          .first()
+      const strength = () =>
+        wrapper.find('.Formol_PasswordStrengthField__description').text()
+      const error = () => wrapper.find('.Formol_Field__error-text').text()
+
+      await input().simulate('focus')
+      await input().simulate('change', { target: { value: 'aa' } })
+      expect(strength()).toEqual('too short')
+
+      await input().simulate('change', { target: { value: 'aaaaaa' } })
+      expect(strength()).toEqual('weak')
+
+      await input().simulate('blur')
+      expect(error()).toEqual('Please choose a more secure password.')
+
+      await input().simulate('focus')
+      await input().simulate('change', { target: { value: 'aaaaaaE!1 ;@' } })
+      expect(strength()).toEqual('strong')
+      expect(wrapper.find('.Formol_Field__error-text')).toHaveLength(0)
+    })
+  })
 })


### PR DESCRIPTION
Reduces strengths to 3 levels:
- too short
- weak
- strong

in order to simplify UX / feedback for some users


https://github.com/Kozea/formol/assets/5930831/62dd0e7c-2d96-4939-b111-f89219002e2f


