### PR TITLE
Rework PasswordStrengthField strength levels

### DIFF
--- a/src/async/PasswordStrengthField.jsx
+++ b/src/async/PasswordStrengthField.jsx
@@ -94,9 +94,9 @@ export default class PasswordStrengthField extends React.PureComponent {
         ]
       : [
           i18n.passwordStrength.tooshort,
+          i18n.passwordStrength.tooweak,
           i18n.passwordStrength.weak,
-          i18n.passwordStrength.okay,
-          i18n.passwordStrength.good,
+          i18n.passwordStrength.average,
           i18n.passwordStrength.strong,
           i18n.passwordStrength.stronger,
         ]

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -25,12 +25,12 @@ export default {
     pattern: /\d{3}[-]\d{3}[-]\d{4}/,
   },
   passwordStrength: {
+    tooshort: 'too short',
+    tooweak: 'too weak',
     weak: 'weak',
-    okay: 'okay',
-    good: 'good',
+    average: 'average',
     strong: 'strong',
     stronger: 'stronger',
-    tooshort: 'too short',
     error: 'Please choose a more secure password.',
   },
   money: {

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -25,12 +25,12 @@ export default {
     placeholder: 'Entrez votre texte ici…',
   },
   passwordStrength: {
-    weak: 'très peu sécurisé',
-    okay: 'peu sécurisé',
-    good: 'correct',
+    tooshort: 'trop court',
+    tooweak: 'très peu sécurisé',
+    weak: 'peu sécurisé',
+    average: 'passable',
     strong: 'sécurisé',
     stronger: 'très sécurisé',
-    tooshort: 'trop court',
     error: 'Veuillez entrer un mot de passe plus sécurisé.',
   },
   money: {

--- a/test/formol/types/password-strength.test.jsx
+++ b/test/formol/types/password-strength.test.jsx
@@ -160,7 +160,7 @@ describe('Password Strength field', () => {
 
     await input().simulate('focus')
     await input().simulate('change', { target: { value: 'passw0rd' } })
-    expect(strength()).toEqual('weak')
+    expect(strength()).toEqual('too weak')
     await input().simulate('blur')
     expect(error()).toEqual('Please choose a more secure password.')
 
@@ -172,7 +172,7 @@ describe('Password Strength field', () => {
 
     await input().simulate('focus')
     await input().simulate('change', { target: { value: 'iamsecret' } })
-    expect(strength()).toEqual('okay')
+    expect(strength()).toEqual('weak')
     await input().simulate('blur')
     expect(error()).toEqual('Please choose a more secure password.')
 


### PR DESCRIPTION
[BREAKING CHANGE] : PasswordStrengthField strength levels keys and translations

* `okay` and `good` levels were confusing and so were their French translation.
* `good` level was below component default `minScore`


https://github.com/Kozea/formol/assets/5930831/502234d0-e6ef-4a85-b400-5b59d42918ca


Currently based upon #108 