### PR TITLE
Add supported node engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,8 @@
   },
   "resolutions": {
     "cheerio": "1.0.0-rc.3"
+  },
+  "engines": {
+    "node": "20.x || 22.x || 24.x"
   }
 }


### PR DESCRIPTION
Works just fine with node 24, so just document it.

Closes #135 