### PR TITLE
Drop zxcvbn password dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
     "react-quill": "^1.3.5",
     "react-select": "^3.2.0",
     "react-text-mask": "^5.5.0",
-    "react-window": "^1.8.11",
-    "zxcvbn": "^4.4.2"
+    "react-window": "^1.8.11"
   },
   "peerDependencies": {
     "date-fns": "^4.4.0",

--- a/src/async/PasswordStrengthField.jsx
+++ b/src/async/PasswordStrengthField.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import zxcvbn from 'zxcvbn'
 
 import { block } from '../utils'
 import PasswordField from '../fields/PasswordField'
+import { getPasswordStrength } from '../utils/password'
 
 /* Inspired from https://github.com/mmw/react-password-strength
    Forked here to handle a value instead of a value and
@@ -10,13 +10,13 @@ import PasswordField from '../fields/PasswordField'
 */
 @block
 export default class PasswordStrengthField extends React.PureComponent {
-  static getState(value, minScore, minLength, userInputs, basic) {
-    const rawScore = zxcvbn(value, userInputs).score
+  static getState(value, minScore, minLength, maxLength, basic) {
+    const rawScore = getPasswordStrength(value, minLength, maxLength).score
 
     return {
       value,
       score:
-        !value || value.length < minLength
+        !value || [...value].length < minLength
           ? -1 // Too short
           : basic
             ? Math.floor(rawScore / minScore)
@@ -25,7 +25,8 @@ export default class PasswordStrengthField extends React.PureComponent {
   }
 
   static defaultProps = {
-    minLength: 5,
+    minLength: 8,
+    maxLength: 64,
     minScore: 3,
   }
 
@@ -40,7 +41,7 @@ export default class PasswordStrengthField extends React.PureComponent {
   }
 
   static getDerivedStateFromProps(
-    { value, userInputs, minLength, minScore, basic },
+    { value, minLength, maxLength, minScore, basic },
     { value: oldValue }
   ) {
     if (value !== oldValue) {
@@ -48,7 +49,7 @@ export default class PasswordStrengthField extends React.PureComponent {
         value,
         minScore,
         minLength,
-        userInputs,
+        maxLength,
         basic
       )
     }
@@ -56,18 +57,17 @@ export default class PasswordStrengthField extends React.PureComponent {
   }
 
   handleChange(value) {
-    const { i18n, minScore, minLength, userInputs, onChange, basic } =
-      this.props
+    const { i18n, minScore, minLength, maxLength, onChange, basic } = this.props
     const state = PasswordStrengthField.getState(
       value,
       minScore,
       minLength,
-      userInputs,
+      maxLength,
       basic
     )
     this.setState((prevState) => ({
       ...state,
-      isPristine: prevState.isPristine && value.length === 0,
+      isPristine: prevState.isPristine && [...value].length === 0,
     }))
     const isTooWeak = basic ? state.score < 1 : state.score < minScore
     onChange(value, isTooWeak ? i18n.passwordStrength.error : '')

--- a/src/utils/password.js
+++ b/src/utils/password.js
@@ -1,0 +1,139 @@
+const SEQUENTIAL_WINDOW_SIZE = 4
+const SEQUENCE_SOURCES = [
+  '01234567890',
+  'abcdefghijklmnopqrstuvwxyz',
+  'azertyuiop',
+  'qsdfghjklm',
+  'wxcvbn',
+  'qwertyuiop',
+  'asdfghjkl',
+  'zxcvbnm',
+]
+
+function generateSequentialTokens(sequence) {
+  const patterns = []
+
+  for (let i = 0; i <= sequence.length - SEQUENTIAL_WINDOW_SIZE; i += 1) {
+    patterns.push(sequence.slice(i, i + SEQUENTIAL_WINDOW_SIZE))
+  }
+
+  return patterns
+}
+
+const SEQUENTIAL_TOKENS = new Set(
+  SEQUENCE_SOURCES.flatMap((source) => [
+    ...generateSequentialTokens(source),
+    ...generateSequentialTokens([...source].reverse().join('')),
+  ])
+)
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i
+
+const ENTROPY_THRESHOLDS = {
+  weak: 30,
+  fair: 48,
+  good: 75,
+  strong: 100,
+}
+
+const LENGTH_THRESHOLDS = {
+  weak: 8,
+  fair: 12,
+  good: 16,
+  strong: 20,
+}
+
+function calculateTotalEntropy(value) {
+  const length = [...value].length
+  if (length === 0) {
+    return 0
+  }
+
+  let poolSize = 0
+  const hasLower = /[a-z]/.test(value)
+  const hasUpper = /[A-Z]/.test(value)
+  const hasDigits = /[0-9]/.test(value)
+  const hasSymbols = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~\s]/.test(value)
+  const hasUnicode = /[^a-zA-Z0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~\s]/.test(
+    value
+  )
+
+  if (hasLower) {
+    poolSize += 26
+  }
+  if (hasUpper) {
+    poolSize += 26
+  }
+  if (hasDigits) {
+    poolSize += 10
+  }
+  if (hasSymbols) {
+    poolSize += 32
+  }
+  if (hasUnicode) {
+    poolSize += 32
+  }
+
+  return Math.log2(poolSize) * length
+}
+
+function isOutsideLengthRange(value, minLength, maxLength) {
+  return [...value].length < minLength || [...value].length > maxLength
+}
+
+function hasRepeatedCharacters(value) {
+  return /(.)\1{2,}/iu.test(value)
+}
+
+function hasSequentialPattern(value) {
+  const normalized = value.toLowerCase()
+  for (let i = 0; i <= normalized.length - SEQUENTIAL_WINDOW_SIZE; i += 1) {
+    const slice = normalized.slice(i, i + SEQUENTIAL_WINDOW_SIZE)
+    if (SEQUENTIAL_TOKENS.has(slice)) {
+      return true
+    }
+  }
+  return false
+}
+
+function isEmailAddress(value) {
+  return EMAIL_REGEX.test(value)
+}
+
+function entropyToScore(entropy) {
+  return Object.values(ENTROPY_THRESHOLDS).filter(
+    (threshold) => entropy >= threshold
+  ).length
+}
+
+function lengthToScore(length) {
+  return Object.values(LENGTH_THRESHOLDS).filter(
+    (threshold) => length >= threshold
+  ).length
+}
+
+export const getPasswordStrength = (value, minLength, maxLength) => {
+  if (!value) {
+    return { score: 0 }
+  }
+
+  if (isOutsideLengthRange(value, minLength, maxLength)) {
+    return { score: 0 }
+  }
+
+  const entropy = calculateTotalEntropy(value)
+  const lengthScore = lengthToScore([...value].length)
+  const entropyScore = entropyToScore(entropy)
+
+  let score = Math.min(lengthScore, entropyScore)
+
+  if (hasRepeatedCharacters(value) || hasSequentialPattern(value)) {
+    score = Math.max(1, score - 1)
+  }
+
+  if (isEmailAddress(value)) {
+    score = Math.min(score, 2)
+  }
+
+  return { score }
+}

--- a/test/formol/types/password-strength.test.jsx
+++ b/test/formol/types/password-strength.test.jsx
@@ -7,7 +7,7 @@ describe('Password Strength field', () => {
   it('handles changes', async () => {
     const onSubmit = jest.fn()
     const wrapper = mount(
-      <Formol onSubmit={onSubmit} item={{ password: 'r"/*Nb+4)23' }}>
+      <Formol onSubmit={onSubmit} item={{ password: 'r"/*Nb+4)23qvDg4"é' }}>
         <Field type="password-strength">Password</Field>
       </Formol>
     )
@@ -24,12 +24,12 @@ describe('Password Strength field', () => {
     expect(submit().props().disabled).toBeTruthy()
     expect(cancel().props().disabled).toBeTruthy()
     expect(input().props().type).toEqual('password')
-    expect(input().props().value).toEqual('r"/*Nb+4)23')
+    expect(input().props().value).toEqual('r"/*Nb+4)23qvDg4"é')
 
     await input().simulate('focus')
-    await input().simulate('change', { target: { value: 'u#@*/p=u58+e' } })
+    await input().simulate('change', { target: { value: 'u#@*/p=u58+e4F9D' } })
     await input().simulate('blur')
-    expect(input().props().value).toEqual('u#@*/p=u58+e')
+    expect(input().props().value).toEqual('u#@*/p=u58+e4F9D')
     expect(submit().props().disabled).toBeFalsy()
     expect(cancel().props().disabled).toBeFalsy()
 
@@ -38,17 +38,17 @@ describe('Password Strength field', () => {
     await submit().simulate('submit')
 
     expect(onSubmit).toHaveBeenCalledWith(
-      { password: 'u#@*/p=u58+e' },
-      { password: 'r"/*Nb+4)23' },
+      { password: 'u#@*/p=u58+e4F9D' },
+      { password: 'r"/*Nb+4)23qvDg4"é' },
       ['password'],
       true
     )
-    expect(input().props().value).toEqual('u#@*/p=u58+e')
+    expect(input().props().value).toEqual('u#@*/p=u58+e4F9D')
   })
   it('cancels changes', async () => {
     const onSubmit = jest.fn()
     const wrapper = mount(
-      <Formol onSubmit={onSubmit} item={{ password: 'r"/*Nb+4)23' }}>
+      <Formol onSubmit={onSubmit} item={{ password: 'r"/*Nb+4)23qvDg4"é' }}>
         <Field type="password-strength">Password</Field>
       </Formol>
     )
@@ -64,7 +64,7 @@ describe('Password Strength field', () => {
 
     expect(submit().props().disabled).toBeTruthy()
     expect(cancel().props().disabled).toBeTruthy()
-    expect(input().props().value).toEqual('r"/*Nb+4)23')
+    expect(input().props().value).toEqual('r"/*Nb+4)23qvDg4"é')
 
     await input().simulate('focus')
     await input().simulate('change', { target: { value: 'u#@*/p=u58+e' } })
@@ -76,11 +76,11 @@ describe('Password Strength field', () => {
 
     await cancel().simulate('click')
 
-    expect(input().props().value).toEqual('r"/*Nb+4)23')
+    expect(input().props().value).toEqual('r"/*Nb+4)23qvDg4"é')
   })
   it('shows password on eye click', async () => {
     const wrapper = mount(
-      <Formol item={{ password: 'r"/*Nb+4)23' }}>
+      <Formol item={{ password: 'r"/*Nb+4)23qvDg4"é' }}>
         <Field type="password-strength">Password</Field>
       </Formol>
     )
@@ -93,10 +93,10 @@ describe('Password Strength field', () => {
     const input = () => wrapper.find('Field').find('input').first()
     const eye = () => wrapper.find('Field').find('.Formol_PasswordField__eye')
 
-    expect(input().props().value).toEqual('r"/*Nb+4)23')
+    expect(input().props().value).toEqual('r"/*Nb+4)23qvDg4"é')
     expect(input().props().type).toEqual('password')
     await eye().simulate('click')
-    expect(input().props().value).toEqual('r"/*Nb+4)23')
+    expect(input().props().value).toEqual('r"/*Nb+4)23qvDg4"é')
     expect(input().props().type).toEqual('text')
 
     await input().simulate('focus')
@@ -119,7 +119,10 @@ describe('Password Strength field', () => {
   it('detects and prevents submission of weak passwords', async () => {
     const onSubmit = jest.fn()
     const wrapper = mount(
-      <Formol onSubmit={onSubmit} item={{ password: 'r"/*Nb+4)23' }}>
+      <Formol
+        onSubmit={onSubmit}
+        item={{ password: 'r"e/*Nb +4)X23q vDg4p"é' }}
+      >
         <Field type="password-strength">Password</Field>
       </Formol>
     )
@@ -139,12 +142,12 @@ describe('Password Strength field', () => {
     expect(submit().props().disabled).toBeTruthy()
     expect(cancel().props().disabled).toBeTruthy()
     expect(input().props().type).toEqual('password')
-    expect(input().props().value).toEqual('r"/*Nb+4)23')
+    expect(input().props().value).toEqual('r"e/*Nb +4)X23q vDg4p"é')
     expect(strength()).toEqual('stronger')
 
     await input().simulate('focus')
     await input().simulate('change', { target: { value: 'passw0rd' } })
-    expect(strength()).toEqual('too weak')
+    expect(strength()).toEqual('weak')
     await input().simulate('blur')
     expect(error()).toEqual('Please choose a more secure password.')
 
@@ -155,12 +158,12 @@ describe('Password Strength field', () => {
     expect(wrapper.getDOMNode().checkValidity()).toBeFalsy()
 
     await input().simulate('focus')
-    await input().simulate('change', { target: { value: 'iamsecret' } })
+    await input().simulate('change', { target: { value: 'iamsecre' } })
     expect(strength()).toEqual('weak')
     await input().simulate('blur')
     expect(error()).toEqual('Please choose a more secure password.')
 
-    expect(input().props().value).toEqual('iamsecret')
+    expect(input().props().value).toEqual('iamsecre')
     expect(submit().props().disabled).toBeFalsy()
     expect(cancel().props().disabled).toBeFalsy()
 
@@ -177,6 +180,28 @@ describe('Password Strength field', () => {
     expect(cancel().props().disabled).toBeFalsy()
 
     expect(wrapper.getDOMNode().checkValidity()).toBeFalsy()
+  })
+  it('counts emojis as single characters', async () => {
+    const wrapper = mount(
+      <Formol>
+        <Field type="password-strength" minLength={8}>
+          Password
+        </Field>
+      </Formol>
+    )
+    const asyncWrapper = () => wrapper.find('AsyncWrapper')
+    await asyncWrapper().instance()._promise
+    wrapper.update()
+
+    const input = () => wrapper.find('Field').find('input').first()
+    const strength = () =>
+      wrapper.find('.Formol_PasswordStrengthField__description').text()
+
+    await input().simulate('focus')
+
+    // 4 emojis = 8 chars in standard .length, but 4 in [...str].length
+    await input().simulate('change', { target: { value: '🐱🐱🐱🐱' } })
+    expect(strength()).toEqual('too short')
   })
   it('has a pristine state', async () => {
     const wrapper = mount(
@@ -232,14 +257,16 @@ describe('Password Strength field', () => {
       await input().simulate('change', { target: { value: 'aa' } })
       expect(strength()).toEqual('too short')
 
-      await input().simulate('change', { target: { value: 'aaaaaa' } })
+      await input().simulate('change', { target: { value: 'aaaaaaaa' } })
       expect(strength()).toEqual('weak')
 
       await input().simulate('blur')
       expect(error()).toEqual('Please choose a more secure password.')
 
       await input().simulate('focus')
-      await input().simulate('change', { target: { value: 'aaaaaaE!1 ;@' } })
+      await input().simulate('change', {
+        target: { value: 'asEftaXyuEP!1 ;@' },
+      })
       expect(strength()).toEqual('strong')
       expect(wrapper.find('.Formol_Field__error-text')).toHaveLength(0)
     })

--- a/test/utils/password.test.js
+++ b/test/utils/password.test.js
@@ -1,0 +1,82 @@
+import { getPasswordStrength } from '../../src/utils/password'
+
+describe('getPasswordStrength', () => {
+  describe('score calculation', () => {
+    it.each([
+      // [password, minLength, maxLength, expected.score, description]
+      ['', null, 64, 0, 'empty password'],
+      ['1234567', 8, 64, 0, 'too short (7 chars < 8 min)'],
+      ['12345678', 8, 64, 1, 'min length met but sequential pattern'],
+      ['aaaaaaaa', 8, 64, 1, 'min length met but repeated characters'],
+      ['bbbbbbbb', 8, 64, 1, 'min length met but repeated characters'],
+      ['abcccdef', 8, 64, 1, 'min length met but repeated characters'],
+      ['aaabcdef', 8, 64, 1, 'min length met but repeated characters'],
+      ['abcdefff', 8, 64, 1, 'min length met but repeated characters'],
+      ['abcde!!!', 8, 64, 1, 'min length met but repeated characters'],
+      ['aaAaaAaa', 8, 64, 1, 'min length met but case-insensitive repetition'],
+      ['chat🐈🐈🐈🐈', 8, 64, 1, 'min length met but repeated characters'],
+      ['aabbccdd', 8, 64, 1, 'repeated pairs'],
+      ['ababab12', 8, 64, 1, 'repeated pattern (ab ab ab)'],
+      ['!!!!!!!!', 8, 64, 1, 'repeated special characters'],
+      ['1111chat', 8, 64, 1, 'repeated digits at the start'],
+      ['ch1111at', 8, 64, 1, 'repeated digits in the middle'],
+      ['chat1111', 8, 64, 1, 'repeated digits at the end'],
+      ['appeller', 8, 64, 1, 'min length met with limited repetition'],
+      ['chat1234', 8, 64, 1, 'min length met but sequential pattern'],
+      ['chat3210', 8, 64, 1, 'min length met but sequential pattern'],
+      ['chatABCD', 8, 64, 1, 'min length met but sequential pattern'],
+      ['chatNMLK', 8, 64, 1, 'min length met but sequential pattern'],
+      ['ab12cd34', 8, 64, 1, 'alternating pattern without true sequence'],
+      ['abcdefgh', 8, 64, 1, 'simple alphabetical sequence'],
+      ['hgfedcba', 8, 64, 1, 'reverse alphabetical sequence'],
+      ['ABC12345', 8, 64, 1, 'numeric sequence after letters'],
+      ['chatAZER', 8, 64, 1, 'min length met but keyboard sequence'],
+      ['chatQSDF', 8, 64, 1, 'min length met but keyboard sequence'],
+      ['chatWXCV', 8, 64, 1, 'min length met but keyboard sequence'],
+      ['chatQWER', 8, 64, 1, 'min length met but keyboard sequence'],
+      ['chaqwert', 8, 64, 1, 'QWERTY keyboard sequence'],
+      ['asdfghjk', 8, 64, 1, 'keyboard sequence (home row)'],
+      ['zxcvbnm?', 8, 64, 1, 'keyboard sequence (bottom row)'],
+      ['qasqas12', 8, 64, 1, 'keyboard pattern with digits'],
+      ['abcdefgh', 8, 64, 1, '8 lowercase letters: ~37 bits'],
+      ['ABCDEFGH', 8, 64, 1, '8 uppercase letters: ~37 bits'],
+      ['abcdef12', 8, 64, 1, '6 letters + 2 digits: ~37 bits'],
+      ['password', 8, 64, 1, 'common 8-char word: ~37 bits'],
+      ['aabbccdd', 8, 64, 1, 'repeated pairs: ~30 bits'],
+      ['Pass1235', 8, 64, 1, 'mixed upper/lower + digits: ~48 bits'],
+      ['Abc12645', 8, 64, 1, '1 uppercase + 3 lowercase + 4 digits: ~43 bits'],
+      ['myPass99', 8, 64, 1, 'letters + digits mix: ~45 bits'],
+      ['ab12cd34', 8, 64, 1, 'alternating letters and digits: ~47 bits'],
+      ['Xy9Zk4Lm', 8, 64, 1, 'mixed case with spaced digits: ~50 bits'],
+      ['Password@1254', 8, 64, 2, 'letters + digits + symbol: ~62 bits'],
+      ['MyP@ss99!QS', 8, 64, 1, '11 chars cap entropy at length score'],
+      ['Kp9#mQ2xL9A', 8, 64, 1, '11 chars cap entropy at length score'],
+      ['Tr0ub4dor&2', 11, 64, 1, '11 varied chars capped by length score'],
+      ['Ej4*pL9#vC4', 8, 64, 1, '11 chars, 4 classes capped by length score'],
+      ['P@ssw0rd#Secure12', 8, 64, 3, '16 varied chars: ~85 bits'],
+      ['MySecureP@ss!2024', 8, 64, 3, '17 chars: ~92 bits'],
+      ['Kx9@mQ#pL$vC2*Rt', 8, 64, 3, '16-char mixed set: ~88 bits'],
+      ['Tr0ub4d0r&C@tfish9', 8, 64, 3, '19 chars: ~95 bits'],
+      ['P@ssw0rd#Secure12!AZ', 8, 64, 4, '20 varied chars: ~104 bits'],
+      ['MySecureP@ss!2024#Xkv', 8, 64, 4, '22 chars: ~114 bits'],
+      ['Kx9@mQ#pL$vC2*Rt!WyZ', 8, 64, 4, '20 chars mixed set: ~108 bits'],
+      ['Tr0ub4d0r&C@tfish99#XyZ', 8, 64, 4, '24 chars: ~128 bits'],
+      ['le chat mange la souris', 8, 64, 4, 'passphrase example'],
+      ['éàùç🐱漢字ΩЖ', 8, 64, 1, 'unicode-only characters are handled as other'],
+      ['email@exemple.com', 8, 64, 2, 'email address'],
+      [
+        'bbNBFt2okt4H03fdrFqlwigHxakPPdCZMEbt65MesByuBC1mxaoHRiYwab4FKjLq',
+        8,
+        64,
+        4,
+        '64 chars accepted',
+      ],
+    ])(
+      'password: "%s" → score %i (%s)',
+      (password, minLength, maxLength, expectedScore) => {
+        const result = getPasswordStrength(password, minLength, maxLength)
+        expect(result.score).toBe(expectedScore)
+      }
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -10293,8 +10293,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zxcvbn@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
-  integrity sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==


### PR DESCRIPTION
zxcvbn adds a large embedded dictionary to formol.js. For issue #121, this dependency represented about 823 kB and a significant part of the client bundle.

Replace zxcvbn scoring in PasswordStrengthField with an internal password-strength utility based on:
- length bounds (min and max)
- repeated character detection
- sequential and keyboard pattern detection
- email-like input detection
- entropy thresholds mapped to scores 0..4

Update defaults to minLength=8 and maxLength=64, remove userInputs from the scoring path, and add focused tests for both the new helper and the password-strength field behavior.

Side effects: password scores can differ from previous zxcvbn results, especially for edge cases, but validation flow is preserved while reducing bundle size.

Close #121